### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ to `/opt/stackstorm/configs/device42.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Supported Actions
 ```
 +-------------------------------+----------+--------------------+---------------------------------------------+

--- a/actions/device_name_list.yaml
+++ b/actions/device_name_list.yaml
@@ -1,6 +1,6 @@
 ---
   name: "device_name_list"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Returns list of devices names"
   enabled: true
   entry_point: "device_name_list.py"

--- a/actions/get_dns_zone.yaml
+++ b/actions/get_dns_zone.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_dns_zone"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Returns DNS zone file"
   enabled: true
   entry_point: "get_dns_zone.py"

--- a/actions/suggest_next_ip.yaml
+++ b/actions/suggest_next_ip.yaml
@@ -1,6 +1,6 @@
 ---
   name: "suggest_next_ip"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Suggest next available IP Address"
   enabled: true
   entry_point: "suggest_next_ip.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: device42
 name: device42
 description: Device42 Actions for StackStorm
-version: 0.3.0
+version: 0.4.0
 author: Device42 Inc.
 email: support@device42.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.