### PR TITLE
Fixing deploy workflow by updating apt cache during this build phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,9 @@ jobs:
           at: /
       - run:
           name: Install dependencies
-          command: sudo apt -y install gmic optipng
+          command: |
+            sudo apt-get update
+            sudo apt -y install gmic optipng
       - run:
           name: Update exchange.stackstorm.org
           command:  ~/ci/.circle/deployment


### PR DESCRIPTION
The master branch on this repo is "protected" so i could push directly to master