### PR TITLE
Quiet pylint no-member error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.7.3
+
+- Quiet pylint no-member error
+
 # 0.7.2
 
 - Add explicit support for Python versions

--- a/actions/get_dns_zone.py
+++ b/actions/get_dns_zone.py
@@ -28,7 +28,7 @@ class GetDnsZone(BaseAction):
                 try:
                     rdtype = dns.rdatatype.from_text(record["type"])
                     rdata = dns.rdata.from_text(
-                        dns.rdataclass.IN, rdtype, record["content"]
+                        dns.rdataclass.IN, rdtype, record["content"]  # pylint: disable=no-member
                     )
                     n = zone.get_rdataset(record["name"], rdtype, create=True)
                     n.add(rdata, record["ttl"])

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: device42
 name: device42
 description: Device42 Actions and Rules for StackStorm
-version: 0.7.2
+version: 0.7.3
 author: Device42 Inc.
 email: support@device42.com
 python_versions:


### PR DESCRIPTION
The pylint checks error out with a `no-member` error, since [`dnspython` dynamically assigns to globals on recent Python 3-only versions](https://github.com/rthalley/dnspython/commit/1fc0bd8e55b526e8220f932485c7c8edcd970be3) (note: don't do that please). This PR disables that pylint check on that line, which should fix [the Python 3 test failures](https://circleci.com/gh/StackStorm-Exchange/stackstorm-device42/242).